### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,16 @@ jobs:
           name: Run tests
           command: yarn test:ci
       - run:
-          name: Send coverage to CodeCov
-          command: yarn add --dev codecov && ./node_modules/.bin/codecov
+          name: Collecting coverage reports
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x ./codecov
+            ./codecov
       - store_test_results:
           path: test-results
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+### CI
+1. [#20](https://github.com/influxdata/influxdb-gds-connector/pull/20): Use new Codecov uploader for reporting code coverage
+
 ## 2021.10 [2021-10-22]
 
 ### Bug Fixes


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
