### PR TITLE
fix: `time` field is mark as a dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+### Bug Fixes
+1. [#23](https://github.com/influxdata/influxdb-gds-connector/pull/23): `time` field is mark as a dimension
+
 ### CI
 1. [#20](https://github.com/influxdata/influxdb-gds-connector/pull/20): Use new Codecov uploader for reporting code coverage
 

--- a/src/InfluxDBClient.js
+++ b/src/InfluxDBClient.js
@@ -203,6 +203,7 @@ InfluxDBClient.prototype.getFields = function (configParams) {
   timestamp.name = '_time'
   timestamp.label = 'time'
   timestamp.dataType = 'STRING'
+  timestamp.defaultAggregationType = 'NONE'
   timestamp.semantics = {}
   timestamp.semantics.isReaggregatable = false
   timestamp.semantics.conceptType = 'DIMENSION'

--- a/test/InfluxDBClient.test.js
+++ b/test/InfluxDBClient.test.js
@@ -240,6 +240,7 @@ describe('get fields', () => {
     })
     expect(fields[10]).toEqual({
       dataType: 'STRING',
+      defaultAggregationType: 'NONE',
       label: 'time',
       name: '_time',
       semantics: {
@@ -344,6 +345,7 @@ describe('get fields', () => {
     })
     expect(fields[6]).toEqual({
       dataType: 'STRING',
+      defaultAggregationType: 'NONE',
       label: 'time',
       name: '_time',
       semantics: {
@@ -535,6 +537,7 @@ describe('get fields', () => {
     })
     expect(fields[1088]).toEqual({
       dataType: 'STRING',
+      defaultAggregationType: 'NONE',
       label: 'time',
       name: '_time',
       semantics: {


### PR DESCRIPTION
Closes #22

## Proposed Changes

We have to set the `defaultAggregationType` config for the `time` to `false`. After that the `time` will be `dimension` (green) type and the LOVs will contains full range of types.

- https://support.google.com/datastudio/answer/6402048?ref_topic=7441655#zippy=%2Cin-this-article
- https://support.google.com/datastudio/thread/18307022
- https://stackoverflow.com/a/66858872

The "blue" is supposed to use for fields with pre-aggregated values.

![image](https://user-images.githubusercontent.com/455137/170242327-73c618d2-6e09-4d3b-b58b-4c49d3906b1a.png)

## The testing version of Connector
https://datastudio.google.com/u/0/datasources/create?connectorId=AKfycbySDF4eD7wmA_awZ6aoCwENuXs1Opw_T0DIJ8F-MVI

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
