### PR TITLE
feat: add detail error message to error dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+### Features
+1. [#25](https://github.com/influxdata/influxdb-gds-connector/pull/25): Add detail error message to error dialog
+
 ### Bug Fixes
 1. [#23](https://github.com/influxdata/influxdb-gds-connector/pull/23): `time` field is mark as a dimension
 

--- a/src/Connector.js
+++ b/src/Connector.js
@@ -254,8 +254,8 @@ function throwUserError(message, error) {
   )
   let text = error.message
     ? `${message}. InfluxDB Error Response: "${error.message}"${
-        error.fluxQuery ? '. Requested Query: "' + error.fluxQuery + '"' : ''
-      }`
+        error.contentMessage ? '. Message: "' + error.contentMessage + '"' : ''
+      }${error.fluxQuery ? '. Requested Query: "' + error.fluxQuery + '"' : ''}`
     : message
   DataStudioApp.createCommunityConnector()
     .newUserError()

--- a/test/InfluxDBClient.test.js
+++ b/test/InfluxDBClient.test.js
@@ -1329,6 +1329,22 @@ describe('contentTextOrThrowUserError', () => {
       expect(e.fluxQuery).toEqual('from() |> ')
     }
   })
+  test('contentMessage', () => {
+    let response = prepareResponse(
+      '{"code":"not found","message":"organization name \\"my-org\\" not found"}',
+      500,
+      {
+        'x-InfluxDB-error': 'header error',
+        'Content-Type': 'application/json; charset=utf-8',
+      }
+    )
+    try {
+      client._contentTextOrThrowUserError(response, 'from() |> ')
+      fail()
+    } catch (e) {
+      expect(e.contentMessage).toEqual('organization name "my-org" not found')
+    }
+  })
   test('flux query json', () => {
     let response = prepareResponse('error body', 500, {
       'x-InfluxDB-error': 'header error',


### PR DESCRIPTION
Closes #24

## Proposed Changes

Add detail error message from response to error dialog:
![Screenshot 2022-06-08 at 11 01 50](https://user-images.githubusercontent.com/455137/172577929-f17807f9-7ad1-4a59-ba13-b3ad04798cbf.png)

## The testing version of Connector
https://datastudio.google.com/u/0/datasources/create?connectorId=AKfycbySDF4eD7wmA_awZ6aoCwENuXs1Opw_T0DIJ8F-MVI

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
